### PR TITLE
I've aligned the schema with the Python implementation for UnaryMinus…

### DIFF
--- a/schema/src/expressions.ts
+++ b/schema/src/expressions.ts
@@ -62,7 +62,7 @@ export type UnaryArithmeticOperator =
   | 'log2'
   | 'abs'
   | 'sqrt'
-  | 'minus'
+  | 'negate'
   | 'floor'
   | 'round'
   | 'ceil';

--- a/software/src/test/expression_tests.py
+++ b/software/src/test/expression_tests.py
@@ -16,6 +16,7 @@ from ptabler.expression import (
     HashExpression,
     StringReplaceExpression,
     FillNaExpression,
+    UnaryMinusExpression,
 )
 
 # Minimal global_settings for tests not relying on file I/O from a specific root_folder
@@ -801,6 +802,47 @@ class StepTests(unittest.TestCase):
         # Sort result by the same keys as expected_df if not already guaranteed by processing
         result_df = result_df.sort(["category", "order_for_first"]) 
         
+        assert_frame_equal(result_df, expected_df, check_dtypes=True)
+
+    def test_add_columns_unary_minus(self):
+        """
+        Tests AddColumns step with a UnaryMinusExpression.
+        Adds a column 'negated_value' = -col("value").
+        """
+        initial_df = pl.DataFrame({
+            "id": [1, 2, 3],
+            "value": [10, -5, 0]
+        }).lazy()
+        initial_table_space: TableSpace = {"input_table": initial_df}
+
+        add_col_step = AddColumns(
+            table="input_table",
+            columns=[
+                ColumnDefinition(
+                    name="negated_value",
+                    expression=UnaryMinusExpression(
+                        value=ColumnReferenceExpression(name="value")
+                    )
+                )
+            ]
+        )
+
+        workflow = PWorkflow(workflow=[add_col_step])
+        final_table_space, _ = workflow.execute(
+            global_settings=global_settings,
+            lazy=True,
+            initial_table_space=initial_table_space
+        )
+
+        expected_df = pl.DataFrame({
+            "id": [1, 2, 3],
+            "value": [10, -5, 0],
+            "negated_value": [-10, 5, 0]
+        })
+
+        result_df = final_table_space["input_table"].collect()
+        # Ensure column order for comparison
+        result_df = result_df.select(expected_df.columns)
         assert_frame_equal(result_df, expected_df, check_dtypes=True)
 
 


### PR DESCRIPTION
… and added a test.

Here's a summary of the changes:

- I modified schema/src/expressions.ts:
    - In UnaryArithmeticOperator, I changed 'minus' to 'negate' to match the tag used in Python's UnaryMinusExpression class. This ensures consistency with Python as the source of truth.

- I added a test for UnaryMinusExpression:
    - I added test_add_columns_unary_minus to software/src/test/expression_tests.py to ensure the UnaryMinusExpression (using tag 'negate') works correctly.

This resolves discrepancies where the schema used 'minus' while the Python implementation expected 'negate' for unary minus operations. I reviewed other parts of the schema and Python code (WindowExpression, DataType aliases, AddColumns, Aggregate) and found them to be adequately aligned or not requiring changes based on the "Python as source of truth" principle and criticality assessment.